### PR TITLE
[PetMatch-16720]: Не работает изменение статуса карточки животного в админке

### DIFF
--- a/src/main/resources/db/changelog/changes/petMatch-16720.xml
+++ b/src/main/resources/db/changelog/changes/petMatch-16720.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd">
+
+    <changeSet id="1" author="undy11203">
+        <dropNotNullConstraint tableName="t_status_comments" columnName="id_status" columnDataType="BIGINT"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
сделал nullable поле id_status
теперь поля status, user, anima_card, animal_card_status все вроде nullable чтобы можно было вставлять в эту таблицу комменты при изменении статусов карточек и пользователей